### PR TITLE
fix rockcraft.yaml for 1.6.1

### DIFF
--- a/1.6.1/rockcraft.yaml
+++ b/1.6.1/rockcraft.yaml
@@ -20,7 +20,7 @@ parts:
     source-type: git
     source-tag: "v1.6.1"
     build-snaps:
-      - go/1.21/stable
+      - go/1.19/stable
     build-packages:
       - make
     override-build: |

--- a/1.6.1/rockcraft.yaml
+++ b/1.6.1/rockcraft.yaml
@@ -18,7 +18,7 @@ parts:
     plugin: go
     source: https://github.com/prometheus/pushgateway
     source-type: git
-    source-tag: "v1.6.0"
+    source-tag: "v1.6.1"
     build-snaps:
       - go/1.21/stable
     build-packages:
@@ -28,6 +28,3 @@ parts:
       install -D -m755 pushgateway ${CRAFT_PART_INSTALL}/bin/pushgateway
     organize:
       pushgateway: bin/pushgateway
-  prometheus-pushgateway:
-    source-tag: v1.6.1
-    build-snaps: go/1.19/stable


### PR DESCRIPTION
This PR fixes rockcraft.yaml for `1.6.1`

# How to test it

Just run: `rockcraft pack` in `1.6.1` directory