### PR TITLE
Install ca-certificates package

### DIFF
--- a/1.6.0/rockcraft.yaml
+++ b/1.6.0/rockcraft.yaml
@@ -20,7 +20,7 @@ parts:
     source-type: git
     source-tag: "v1.6.0"
     build-snaps:
-      - go/1.21/stable
+      - go/1.19/stable
     build-packages:
       - make
     override-build: |

--- a/1.6.0/rockcraft.yaml
+++ b/1.6.0/rockcraft.yaml
@@ -28,3 +28,7 @@ parts:
       install -D -m755 pushgateway ${CRAFT_PART_INSTALL}/bin/pushgateway
     organize:
       pushgateway: bin/pushgateway
+  # We moved this here because: https://github.com/canonical/rockcraft/issues/343
+  ca-certs:
+    plugin: nil
+    stage-packages: [ca-certificates]

--- a/1.6.1/rockcraft.yaml
+++ b/1.6.1/rockcraft.yaml
@@ -28,3 +28,7 @@ parts:
       install -D -m755 pushgateway ${CRAFT_PART_INSTALL}/bin/pushgateway
     organize:
       pushgateway: bin/pushgateway
+  # We moved this here because: https://github.com/canonical/rockcraft/issues/343
+  ca-certs:
+    plugin: nil
+    stage-packages: [ca-certificates]


### PR DESCRIPTION
This PR fixes #7

# How to test it

1. Build the image: `rockcraft pack`
2. Copy the image to a oci-archive: `skopeo --insecure-policy copy oci-archive:prometheus-pushgateway_1.6.1_amd64.rock docker-daemon:pushgateway:1.6.1`
3. Run the image: `docker run -it --rm IMAGE_ID`
4. Run `update-ca-certificates` in container: `docker exec -it CONTAINER_NAME update-ca-certificates`
