### PR TITLE
fix ca-certificates issues

### DIFF
--- a/1.6.0/rockcraft.yaml
+++ b/1.6.0/rockcraft.yaml
@@ -33,7 +33,7 @@ parts:
   # We moved this here because: https://github.com/canonical/rockcraft/issues/343
   ca-certs:
     plugin: nil
-    stage-packages: [ca-certificates]
+    overlay-packages: [ca-certificates]
   deb-security-manifest:
     plugin: nil
     after:

--- a/1.6.1/rockcraft.yaml
+++ b/1.6.1/rockcraft.yaml
@@ -33,7 +33,7 @@ parts:
   # We moved this here because: https://github.com/canonical/rockcraft/issues/343
   ca-certs:
     plugin: nil
-    stage-packages: [ca-certificates]
+    overlay-packages: [ca-certificates]
   deb-security-manifest:
     plugin: nil
     after:

--- a/1.6.2/rockcraft.yaml
+++ b/1.6.2/rockcraft.yaml
@@ -33,7 +33,7 @@ parts:
   # We moved this here because: https://github.com/canonical/rockcraft/issues/343
   ca-certs:
     plugin: nil
-    stage-packages: [ca-certificates]
+    overlay-packages: [ca-certificates]
   deb-security-manifest:
     plugin: nil
     after:

--- a/1.7.0/rockcraft.yaml
+++ b/1.7.0/rockcraft.yaml
@@ -33,7 +33,7 @@ parts:
   # We moved this here because: https://github.com/canonical/rockcraft/issues/343
   ca-certs:
     plugin: nil
-    stage-packages: [ca-certificates]
+    overlay-packages: [ca-certificates]
   deb-security-manifest:
     plugin: nil
     after:


### PR DESCRIPTION
## Issue
Currently, the `ca-certificates` package is added to the rock, but it's missing the default certificates in `/etc/ssl/certs`.

This happens not because we don't stage them, but because `stage-packages: [ca-certificates]` doesn't run the maintainer scripts that would populate `/etc/ssl/certs`, so that folder stays empty.

## Solution
The solution to this is to change `stage-packages:` to `overlay-packages` in the `ca-certs` part, because that also runs the maintainer scripts and correctly populates the `/ets/ssl/certs` folder.

## Testing Instructions

You can test it yourself by simply running the rock and checking the certs are there via `ls /etc/ssl/certs`.

```bash
root@8f0199aebc08:/# which update-ca-certificates
/usr/sbin/update-ca-certificates
root@8f0199aebc08:/# ll /etc/ssl/certs/
total 604
```