### PR TITLE
Fix `rock-update` workflow

### DIFF
--- a/.github/workflows/rock-update.yaml
+++ b/.github/workflows/rock-update.yaml
@@ -3,7 +3,7 @@ name: Update rock
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 0,4,8,12,16,20 * * *'
+    - cron: '0 0 * * *'
 
 jobs:
   build:
@@ -12,3 +12,4 @@ jobs:
       rock-name: prometheus-pushgateway
       source-repo: prometheus/pushgateway
       check-go: true
+    secrets: inherit


### PR DESCRIPTION
## Issue
The CI workflow is missing a `secrets: inherit` to run

